### PR TITLE
Added strings in Italian translation

### DIFF
--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -221,12 +221,16 @@
   <string name="pref_toast_duration_summary">Seleziona quanto a lungo dovranno rimanere visibili le notifiche</string>
   <string name="pref_toast_block_apps">Blocca apps</string>
   <string name="pref_toast_apps_summary">Seleziona quali app non dovranno avere le notifiche</string>
+  <string name="pref_toast_show_address_title">Mostra indirizzo</string>
+  <string name="pref_toast_show_address_summary">Includi indirizzo IP nella notifica</string>
 
   <string name="pref_graphs">Opzioni per grafico</string>
   <string name="pref_interval_title">Intervallo</string>
   <string name="pref_interval_summary">Indica quanto spesso i dati dovranno essere sommati. Per visualizzare singoli pacchetti, setta ad 1 ms; per Kbps, setta a 1 secondo; per Kb/ora setta a 1 ora; ecc...</string>
   <string name="pref_viewsize_title">Finestra di visualizzazione</string>
   <string name="pref_viewsize_summary">Indica il range di tempo della finestra di visualizzazione dei dati. Se il range scelto è più largo del range dei dati, la finestra si ridurrà al fine di adattarsi.</string>
+  <string name="pref_throughput_bps_title">Visualizza traffico in bits/secondo</string>
+  <string name="pref_throughput_bps_summary">Se selezionato, il traffico verrà visualizzato in bits/secondo, altrimenti bytes/secondo</string>
 
   <string name="pref_debugging">Opzioni di debug</string>
   <string name="pref_debug_title">Log extra debug</string>


### PR DESCRIPTION
Translation of:

``` xml
<string name="pref_toast_show_address_title">Show address</string>
<string name="pref_toast_show_address_summary">Include the IP address in the toast notification</string>
<string name="pref_throughput_bps_title">Show traffic as bits-per-second</string>
<string name="pref_throughput_bps_summary">If selected, traffic speeds will be shown as bits-per-second; otherwise as bytes-per-second</string>
```
